### PR TITLE
Example component unit test

### DIFF
--- a/app/app.tests.js
+++ b/app/app.tests.js
@@ -2,5 +2,5 @@
 
 import 'babel-core/polyfill';
 
-let context = require.context('.', true, /-test\.jsx?$/);
+let context = require.context('.', true, /\-test\.js(x|)?$/);
 context.keys().forEach(context);

--- a/app/components/MovieTile/MovieTile-test.jsx
+++ b/app/components/MovieTile/MovieTile-test.jsx
@@ -1,0 +1,26 @@
+/* globals beforeEach, expect */
+/* eslint-disable no-unused-expressions, no-unused-vars */
+
+import React from 'react/addons';
+import TestUtils from 'react/lib/ReactTestUtils';
+import { expect } from 'chai';
+import MovieTile from './MovieTile';
+
+
+describe('Components', () => {
+  describe('MovieTile', () => {
+    let component, props;
+
+    beforeEach(() => {
+      let element = React.createElement(MovieTile, props);
+      component = TestUtils.renderIntoDocument(element);
+    });
+
+    it('should render into the document', () => {
+      let result = TestUtils.findRenderedDOMComponentWithClass(component, 'movie-tile-container');
+      expect(result).to.be.defined;
+    });
+  });
+});
+
+/* eslint-enable no-unused-expressions */

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,10 +15,11 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: [/*'Chrome', */'PhantomJS'],
-    singleRun: false,
+    singleRun: true,
     webpack: require('./webpack/config.test'),
     webpackMiddleware: {
-      noInfo: true
+      noInfo: true,
+      quiet: false
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "glob": "^5.0.6",
     "html-loader": "^0.3.0",
     "json-loader": "^0.5.1",
-    "karma": "^0.12.31",
+    "karma": "^0.13.3",
     "karma-chrome-launcher": "^0.1.12",
     "karma-cli": "0.0.4",
     "karma-mocha": "^0.1.10",

--- a/webpack/simpledemo.js
+++ b/webpack/simpledemo.js
@@ -1,5 +1,5 @@
-var pkg  = require('../package.json'),
-    path = require('path');
+var pkg = require('../package.json');
+var path = require('path');
 
 var DEBUG = process.env.NODE_ENV === 'development';
 var TEST = process.env.NODE_ENV === 'test';
@@ -25,4 +25,4 @@ module.exports = {
       './public/scripts/dist/'
     ]
   }
-}
+};


### PR DESCRIPTION
Updating the project config to enable component unit tests and including a very basic component unit test.

Noteworthy mentions:
- Updated karma version to `0.13.3` after encountering a `karma-webpack` [issue](https://github.com/webpack/karma-webpack/issues/65).
- Fixed some linter warnings in `webpack/simpledemo.js`
- Changed context file extension regex to catch both `*-test.jsx` and `*-test.js` 
